### PR TITLE
fix(vue): destroy componentInstance and not the parent component

### DIFF
--- a/src/collectionview/vue/component.ts
+++ b/src/collectionview/vue/component.ts
@@ -79,8 +79,8 @@ export default {
         },
         onItemDisposingInternal(args) {
             const oldVnode = args.view && args.view[VUE_VIEW];
-            if (oldVnode && oldVnode.context) {
-                oldVnode.context.$destroy();
+            if (oldVnode && oldVnode.componentInstance) {
+                oldVnode.componentInstance.$destroy();
                 args.view[VUE_VIEW] = null;
             }
         },


### PR DESCRIPTION
`context` points to the parent component, so in some cases this would destroy a parent component instance, causing reactivity and interaction to stop working.

Changing it to `componentInstance` should now correctly destroy the component instance for the cell rather than any parent.

https://github.com/vuejs/vue/blob/8d3fce029f20a73d5d0b1ff10cbf6fa73c989e62/src/core/vdom/vnode.js#L13