### PR TITLE
fix(vue): properly dispose vnodes

### DIFF
--- a/src/collectionview/vue/component.ts
+++ b/src/collectionview/vue/component.ts
@@ -79,9 +79,9 @@ export default {
         },
         onItemDisposingInternal(args) {
             const oldVnode = args.view && args.view[VUE_VIEW];
-            if (oldVnode && oldVnode.componentInstance) {
-                oldVnode.componentInstance.$destroy();
-                args.view[VUE_VIEW] = null;
+            if (oldVnode) {
+                // properly dispose the oldVnode (this will unmount the tree)
+                this.__patch__(oldVnode, null);
             }
         },
         refresh() {


### PR DESCRIPTION
This fixes issue my previous PR fixed in #50 however also accounts for cases where the template/root vnode is not a component but a layout like `<GridLayout>`.

With this change, we patch the vnode with a `null` vnode - causing vue to properly dispose the whole subtree and triggering all the `beforeDestroy` and `destroyed` hooks correctly.