### PR TITLE
fix: Infinite recursion on scrollToIndex with vue3 component;

### DIFF
--- a/src/collectionview/vue3/component.ts
+++ b/src/collectionview/vue3/component.ts
@@ -121,10 +121,6 @@ export const CollectionView = defineComponent({
                 return vnode;
             });
 
-        function scrollToIndex(index: number, animate = false) {
-            (collectionView.value.nativeView as NSCollectionView).scrollToIndex(index, animate);
-        }
-
         return () =>
             h(
                 'NativeCollectionView',
@@ -132,8 +128,7 @@ export const CollectionView = defineComponent({
                     ref: collectionView,
                     items: props.items,
                     itemTemplates,
-                    onItemLoading,
-                    scrollToIndex
+                    onItemLoading
                 },
                 cellVNODES()
             );


### PR DESCRIPTION
In my vue3 project I was getting an infinite recursion doing (Android and iOS):

```js
const listComponent = ref( null );

const scrollToBottom = () => {
    listComponent.value.$el.nativeView.scrollToIndex( 0, true );
};
```
The infinite recursion was happening int the function `function scrollToIndex(index: number, animate = false)` added [here](https://github.com/nativescript-community/ui-collectionview/commit/3c15989085e8374eb0745a1b7fa2cd30e17a77a4).

I just removed the function and it now works. I don't know why it was added. I couldn't access the function directly in the component with `listComponent.value.scrollToIndex( 0, true );`

Works well on both Android and iOS.

Thanks!