### PR TITLE
feat: shared view pools [wip]

### DIFF
--- a/src/collectionview/index-common.ts
+++ b/src/collectionview/index-common.ts
@@ -138,6 +138,8 @@ export abstract class CollectionViewBase extends View implements CollectionViewD
     protected _dataUpdatesSuspended = false;
     public scrollBarIndicatorVisible: boolean;
 
+    public sharedPool: string;
+
     public layoutStyle: string = 'grid';
     public plugins: string[] = [];
     public static plugins: { [k: string]: Plugin } = {};
@@ -743,3 +745,8 @@ export const autoReloadItemOnLayoutProperty = new Property<CollectionViewBase, b
     valueConverter: booleanConverter
 });
 autoReloadItemOnLayoutProperty.register(CollectionViewBase);
+
+export const sharedPoolProperty = new Property<CollectionViewBase, string>({
+    name: 'sharedPool'
+});
+sharedPoolProperty.register(CollectionViewBase);

--- a/src/collectionview/shared-pool-common.ts
+++ b/src/collectionview/shared-pool-common.ts
@@ -1,0 +1,72 @@
+import { Trace, View } from '@nativescript/core';
+import { CLog, CLogTypes, CollectionViewBase } from './index-common';
+
+const poolMap = new Map<string, SharedCollectionViewPoolBase>();
+export function getSharedCollectionViewPool(name: string): SharedCollectionViewPoolBase | undefined {
+    return poolMap.get(name);
+}
+
+export class SharedCollectionViewPoolBase extends CollectionViewBase {
+    protected collectionViews = new Set<CollectionViewBase>();
+    protected _name: string;
+
+    set name(value: string) {
+        if (this._name !== value) {
+            poolMap.delete(this._name);
+        }
+        this._name = value;
+        poolMap.set(this._name, this);
+    }
+
+    get name(): string {
+        return this._name;
+    }
+
+    public onLoaded(): void {
+        super.onLoaded();
+        poolMap.set(this.name, this);
+    }
+
+    public onUnloaded(): void {
+        super.onUnloaded();
+        poolMap.delete(this.name);
+    }
+
+    public attachToCollectionView(collectionView: CollectionViewBase): void {
+        if (Trace.isEnabled()) {
+            CLog(CLogTypes.log, 'attachToCollectionView', collectionView);
+        }
+
+        this.collectionViews.add(collectionView);
+    }
+
+    public detachFromCollectionView(collectionView: CollectionViewBase): void {
+        if (Trace.isEnabled()) {
+            CLog(CLogTypes.log, 'detachFromCollectionView', collectionView);
+        }
+
+        this.collectionViews.delete(collectionView);
+    }
+
+    public refresh() {
+        throw new Error('Method not implemented.');
+    }
+    public refreshVisibleItems() {
+        throw new Error('Method not implemented.');
+    }
+    public isItemAtIndexVisible(index: number) {
+        throw new Error('Method not implemented.');
+    }
+    public scrollToIndex(index: number, animated: boolean) {
+        throw new Error('Method not implemented.');
+    }
+    public scrollToOffset(value: number, animated?: boolean) {
+        throw new Error('Method not implemented.');
+    }
+    getViewForItemAtIndex(index: number): View {
+        throw new Error('Method not implemented.');
+    }
+    startDragging(index: number) {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/collectionview/shared-pool.android.ts
+++ b/src/collectionview/shared-pool.android.ts
@@ -1,0 +1,96 @@
+import { ContentView, Trace, View } from '@nativescript/core';
+import { CLog, CLogTypes, CollectionViewBase } from './index-common';
+import { SharedCollectionViewPoolBase } from './shared-pool-common';
+
+interface CollectionViewCellHolder extends com.nativescript.collectionview.CollectionViewCellHolder {
+    // tslint:disable-next-line:no-misused-new
+    new (androidView: android.view.View): CollectionViewCellHolder;
+    view: View;
+    clickListener: android.view.View.OnClickListener;
+}
+
+export class SharedCollectionViewPool extends SharedCollectionViewPoolBase {
+    private recyclerListener: androidx.recyclerview.widget.RecyclerView.RecyclerListener;
+    private recycledViewPool: com.nativescript.collectionview.RecycledViewPool;
+    private recycledViewPoolDisposeListener: com.nativescript.collectionview.RecycledViewPool.ViewPoolListener;
+
+    // used to store viewHolder and thus their corresponding Views
+    // used to "destroy" cells when possible
+    public _viewHolders = new Set<CollectionViewCellHolder>();
+
+    public createNativeView() {
+        // no need to create anything
+        return null;
+    }
+
+    public initNativeView(): void {
+        // const nativeView = this.nativeViewProtected;
+        this.recycledViewPool = new com.nativescript.collectionview.RecycledViewPool();
+        this.recycledViewPoolDisposeListener = new com.nativescript.collectionview.RecycledViewPool.ViewPoolListener({
+            onViewHolderDisposed: (holder: CollectionViewCellHolder) => {
+                if (Trace.isEnabled()) {
+                    CLog(CLogTypes.log, 'onViewHolderDisposed', holder);
+                }
+                if (this._viewHolders) {
+                    this._viewHolders.delete(holder);
+                }
+                const isNonSync = holder['defaultItemView'] === true;
+                const view = isNonSync ? (holder.view as ContentView).content : holder.view;
+                this.notifyForItemAtIndex(CollectionViewBase.itemDisposingEvent, view, holder.getAdapterPosition(), view.bindingContext, holder);
+                if (view && view.isLoaded) {
+                    view.callUnloaded();
+                }
+                view._isAddedToNativeVisualTree = false;
+                //@ts-ignore
+                view.parent = null;
+                view._tearDownUI();
+            }
+        });
+        (this.recycledViewPool as any).mListener = this.recycledViewPoolDisposeListener;
+
+        this.recyclerListener = new androidx.recyclerview.widget.RecyclerView.RecyclerListener({
+            onViewRecycled: (holder: CollectionViewCellHolder) => {
+                if (Trace.isEnabled()) {
+                    CLog(CLogTypes.log, 'onViewRecycled', holder);
+                }
+                const isNonSync = holder['defaultItemView'] === true;
+                const view = isNonSync ? (holder.view as ContentView).content : holder.view;
+                this.notifyForItemAtIndex(CollectionViewBase.itemRecyclingEvent, view, holder.getAdapterPosition(), view.bindingContext, holder);
+            }
+        });
+    }
+
+    public disposeNativeView() {
+        this.collectionViews.forEach((collectionView) => {
+            const nativeView = collectionView.nativeViewProtected;
+            nativeView.setRecyclerListener(null);
+            nativeView.setRecycledViewPool(null);
+        });
+        this.collectionViews.clear();
+        this.recycledViewPoolDisposeListener = null;
+        this.recycledViewPool = null;
+        super.disposeNativeView();
+    }
+
+    public attachToCollectionView(collectionView: CollectionViewBase): void {
+        super.attachToCollectionView(collectionView);
+
+        const nativeView = collectionView.nativeViewProtected;
+        nativeView.setRecyclerListener(this.recyclerListener);
+        nativeView.setRecycledViewPool(this.recycledViewPool);
+    }
+
+    public detachFromCollectionView(collectionView: CollectionViewBase): void {
+        super.detachFromCollectionView(collectionView);
+
+        const nativeView = collectionView.nativeViewProtected;
+        nativeView.setRecyclerListener(null);
+        nativeView.setRecycledViewPool(null);
+    }
+
+    notifyForItemAtIndex(eventName: string, view: View, index: number, bindingContext?, native?: any) {
+        const args = { eventName, object: this, index, view, ios: native, bindingContext };
+        this.notify(args);
+        return args as any;
+    }
+}

--- a/src/collectionview/shared-pool.d.ts
+++ b/src/collectionview/shared-pool.d.ts
@@ -1,0 +1,9 @@
+import { SharedCollectionViewPoolBase } from './shared-pool-common';
+
+export { getSharedCollectionViewPool } from './shared-pool-common';
+
+export class SharedCollectionViewPool extends SharedCollectionViewPoolBase {
+    //
+
+    public _viewHolders: any;
+}

--- a/src/collectionview/shared-pool.ios.ts
+++ b/src/collectionview/shared-pool.ios.ts
@@ -1,0 +1,3 @@
+import { SharedCollectionViewPoolBase } from './shared-pool-common';
+
+export class SharedCollectionViewPool extends SharedCollectionViewPoolBase {}


### PR DESCRIPTION
This is a draft/wip branch of implementing shared view pools.

Shared pools will allow defining the item templates in a separate view/element, and reuse them for multiple CollectionViews. This is especially useful for nested CollectionViews, where we may have multiple CollectionViews rendering the same templates.

For simplicity, pool related logic has been moved to a new `SharedCollectionViewPool` class, so even if the view doesn't share the pool, it will still create one automatically and use that (rather than duplicating the logic in both classes).

todos:
 - handle unloading/re-loading the view
 - thoroughly test to make sure recycling behaves correctly
 - implement iOS (at least supporting using templates from the `SharedCollectionViewPool`
 - refine api, property naming
 - add demos
 - add framework wrappers
 - document usage