### PR TITLE
Fix: Vue3 global properties not available in slot

### DIFF
--- a/src/collectionview/vue3/component.ts
+++ b/src/collectionview/vue3/component.ts
@@ -73,8 +73,9 @@ export const CollectionView = defineComponent({
         function onItemLoading(event: any & ItemEventData) {
             const index = event.index;
             const id = event.view?.[LIST_CELL_ID] ?? `${cellId++}`;
+            const item = defineComponent(event.bindingContext, vm);
 
-            const itemCtx = getItemCtx(event.bindingContext, index, props.alias, props.itemIdGenerator);
+            const itemCtx = getItemCtx(item, index, props.alias, props.itemIdGenerator);
             // const itemCtx: ListItem = getItemCtx(props.items instanceof ObservableArray ? props.items.getItem(index) : props.items[index], index, props.alias, props.itemIdGenerator);
 
             // update the cell data with the current row


### PR DESCRIPTION
This PR makes global properties available in the slot. 
Global properties are not recommended to use, but are part of Vue3 to enable migration from Vue2 projects.

## Current behaviour

The following code will throw an error, because `$L` is not defined on the context.

~~~ts
// app.ts

const app = createApp({});
app.config.globalProperties.$L = localize;
~~~

~~~ts
// MyList.vue

<CollectionView :items="items">
   <template #default="{ item }">
       <Label :text="$L('Hello world')" />
   </template>
</CollectionView>
~~~


