### PR TITLE
Add findLastVisibleItemIndex and fix ios findFirstVisibleItemIndex

### DIFF
--- a/src/collectionview/index-common.ts
+++ b/src/collectionview/index-common.ts
@@ -180,6 +180,7 @@ export abstract class CollectionViewBase extends View implements CollectionViewD
     public abstract refreshVisibleItems();
     public abstract isItemAtIndexVisible(index: number);
     public abstract findFirstVisibleItemIndex(): number;
+    public abstract findLastVisibleItemIndex(): number;
     public abstract scrollToIndex(index: number, animated: boolean);
     public abstract scrollToOffset(value: number, animated?: boolean): any;
 

--- a/src/collectionview/index.android.ts
+++ b/src/collectionview/index.android.ts
@@ -985,7 +985,7 @@ export class CollectionView extends CollectionViewBase {
             return -1;
         }
         const layoutManager = this.layoutManager as androidx.recyclerview.widget.LinearLayoutManager;
-        if (layoutManager['findFirstVisibleItemPosition']) {
+        if (layoutManager['findLastVisibleItemPosition']) {
             return layoutManager.findLastVisibleItemPosition();
         }
         return -1;

--- a/src/collectionview/index.android.ts
+++ b/src/collectionview/index.android.ts
@@ -979,6 +979,17 @@ export class CollectionView extends CollectionViewBase {
         }
         return -1;
     }
+    public findLastVisibleItemIndex() {
+        const view = this.nativeViewProtected;
+        if (!view) {
+            return -1;
+        }
+        const layoutManager = this.layoutManager as androidx.recyclerview.widget.LinearLayoutManager;
+        if (layoutManager['findFirstVisibleItemPosition']) {
+            return layoutManager.findLastVisibleItemPosition();
+        }
+        return -1;
+    }
 
     _layedOut = false;
     @profile

--- a/src/collectionview/index.d.ts
+++ b/src/collectionview/index.d.ts
@@ -15,6 +15,7 @@ export class CollectionView extends CollectionViewBase {
     public refreshVisibleItems();
     public isItemAtIndexVisible(index: number): boolean;
     public findFirstVisibleItemIndex(): number;
+    public findLastVisibleItemIndex(): number;
     public scrollToIndex(index: number, animated?: boolean, snap?: SnapPosition = SnapPosition.START);
     public scrollToOffset(value: number, animation?: boolean);
     public getViewForItemAtIndex(index: number): View;

--- a/src/collectionview/index.ios.ts
+++ b/src/collectionview/index.ios.ts
@@ -679,11 +679,23 @@ export class CollectionView extends CollectionViewBase {
         if (!view) {
             return -1;
         }
-        const indexes = Array.from<NSIndexPath>(view.indexPathsForVisibleItems)
-            .map((e) => e.row)
-            .sort();
-        return indexes[0] ?? -1;
+
+        return this.getRowIndexPath(view)[0] ?? -1;
     }
+    public findLastVisibleItemIndex() {
+        const view = this.nativeViewProtected;
+        if (!view) {
+            return -1;
+        }
+        return this.getRowIndexPath(view).at(-1) ?? -1;
+    }
+
+    private getRowIndexPath(view: UICollectionView){
+        return Array.from<NSIndexPath>(view.indexPathsForVisibleItems)
+            .map((e) => e.row)
+            .sort((a, b) => a - b);
+    }
+
     @profile
     public refresh() {
         if (!this.isLoaded || !this.nativeView) {


### PR DESCRIPTION
I have fixed a bug that was on the iOS side for findFirstVisibleItemIndex, the `sort` was not being done correctly.

I have also added a utility method `findLastVisibleItemIndex` similar to findFirstVisibleItemIndex