### PR TITLE
fix(android): swap width/height spanSize multiplication in onBindViewHolder

### DIFF
--- a/src/collectionview/index.android.ts
+++ b/src/collectionview/index.android.ts
@@ -1371,9 +1371,9 @@ export class CollectionView extends CollectionViewBase {
             const spanSize = this._getSpanSize(bindingContext, position);
             const horizontal = this.isHorizontal();
             if (horizontal) {
-                width *= spanSize;
-            } else {
                 height *= spanSize;
+            } else {
+                width *= spanSize;
             }
         }
         if (width || !view.width) {


### PR DESCRIPTION
## Summary

- Commit fe649dc ("Add support for rowHeight per template") accidentally swapped the `width`/`height` multiplication when applying `spanSize` on Android in `onBindViewHolder`.
- For a **vertical** CollectionView, `spanSize` should multiply the **width** (item spans across columns). Instead, it was multiplying the **height**, causing items with `spanSize > 1` to be rendered taller but only occupy one column.
- The iOS implementation (`index.ios.ts`) was **not affected** and already has the correct logic.

### Before (broken)
```typescript
if (horizontal) {
    width *= spanSize;   // wrong — should be height
} else {
    height *= spanSize;  // wrong — should be width
}
```

### After (fixed, matches iOS)
```typescript
if (horizontal) {
    height *= spanSize;
} else {
    width *= spanSize;
}
```

## Test plan

- [ ] Vertical CollectionView with `colWidth="33.3%"` (3 columns) and an item with `spanSize=3` — should span full width
- [ ] Horizontal CollectionView with `rowHeight` set and an item with `spanSize > 1` — should span multiple rows
- [ ] Items with `spanSize=1` should be unaffected
- [ ] iOS behavior should remain unchanged