### PR TITLE
fix(ui-collectionview): New cell views are not added to measuring cache

### DIFF
--- a/src/collectionview/index.ios.ts
+++ b/src/collectionview/index.ios.ts
@@ -1220,7 +1220,7 @@ export class CollectionView extends CollectionViewBase {
 
                 // Cell preparation may have replaced the view with a new one if collection view listens to itemLoading event
                 // so check if cell view changed and update measure cell cache
-                if (needsSet || measureData && measureData.view != cell.view) {
+                if (needsSet || measureData && cell && measureData.view != cell.view) {
                     this._measureCellMap.set(templateType, { cell, view: cell.view });
                 }
             }

--- a/src/collectionview/index.ios.ts
+++ b/src/collectionview/index.ios.ts
@@ -1215,8 +1215,12 @@ export class CollectionView extends CollectionViewBase {
                     cell.owner = new WeakRef(measureData.view);
                     needsSet = true;
                 }
+
                 measuredSize = this._prepareCell(cell, indexPath, templateType, false);
-                if (needsSet) {
+
+                // Cell preparation may have replaced the view with a new one if collection view listens to itemLoading event
+                // so check if cell view changed and update measure cell cache
+                if (needsSet || measureData && measureData.view != cell.view) {
                     this._measureCellMap.set(templateType, { cell, view: cell.view });
                 }
             }


### PR DESCRIPTION
It seems that the current iOS measure caching mechanism does not consider the possibility of the `itemLoading` listener replacing the cell view.
So, the problem is that the new cell view doesn't belong to any cache and has no strong reference, so garbage collection meddles with it.
This can result in a chain of events that cause apps to crash in production.