### PR TITLE
fix(ios): only allow drag reorder when reordering is enabled

### DIFF
--- a/src/collectionview/index-common.ts
+++ b/src/collectionview/index-common.ts
@@ -581,9 +581,15 @@ export abstract class CollectionViewBase extends View implements CollectionViewD
     }
 
     shouldMoveItemAtIndex(index: number) {
-        // if (!this.reorderEnabled) {
-        //     return false;
-        // }
+        // On iOS this also answers `collectionView:canMoveItemAtIndexPath:`. Answering yes
+        // unconditionally lets UIKit install its own drag-to-reorder interaction wherever
+        // `dragInteractionEnabled` is on — the default for the iPad idiom, and therefore for
+        // Mac Catalyst: cells of lists that never opted into reordering lift under the pointer
+        // and get reordered on drop. Both flags are checked so that enabling only
+        // `reorderLongPressEnabled` keeps working (see 0fc0e91).
+        if (!this.reorderEnabled && !this.reorderLongPressEnabled) {
+            return false;
+        }
         const item = this.getItemAtIndex(index);
         const view = (this.draggingView = this.getViewForItemAtIndex(index));
         let args = {


### PR DESCRIPTION
## Summary

- `shouldMoveItemAtIndex` also answers `collectionView:canMoveItemAtIndexPath:`. Since 0fc0e91 it returned `true` unconditionally, telling UIKit that every cell of every collection view may be moved.
- On iPhone this goes unnoticed, because `UICollectionView.dragInteractionEnabled` defaults to `false` for the phone idiom. The **iPad idiom — and therefore Mac Catalyst — defaults to `true`**, so UIKit installs its own drag-to-reorder interaction: cells of lists that never opted into reordering lift under the pointer and get reordered on drop.
- Restores the guard 0fc0e91 removed, widened to accept **either** flag so that enabling only `reorderLongPressEnabled` keeps working — which is exactly what that commit was fixing. A plain revert would regress it.

Worth noting the reorder happens entirely inside UIKit: no drag delegate is involved (both are commented out), and none of the plugin's own interactive-movement calls run. Instrumenting `startDragging`, `onReorderingTouch` and `onReorderLongPress` showed all three silent while a cell was being dragged and dropped into a new position.

## Testing

Built a real app (OSS Weather) as a Mac Catalyst app on Apple Silicon and checked both directions:

- a horizontal list setting neither flag: cells no longer lift or reorder on click-drag (previously they did)
- a list setting both `reorderEnabled` and `reorderLongPressEnabled`: long-press-drag still reorders normally

`tsc --build` reports the same 2 pre-existing errors as `master` (`Builder.parseMultipleTemplates` arity), untouched by this change.