### PR TITLE
fix(android): stable template view types and no dropped data changes

### DIFF
--- a/src/collectionview/index.android.ts
+++ b/src/collectionview/index.android.ts
@@ -159,6 +159,7 @@ export class CollectionView extends CollectionViewBase {
     private templateTypeNumberString = new Map<string, number>();
     private templateStringTypeNumber = new Map<number, string>();
     private _currentNativeItemType = 0;
+    private _pendingRefresh = false;
 
     private currentSpanCount = 1;
 
@@ -908,6 +909,19 @@ export class CollectionView extends CollectionViewBase {
     }
     public onSourceCollectionChanged(event: ChangedData<any>) {
         if (!this._listViewAdapter || this._dataUpdatesSuspended || this.nativeViewProtected.isComputingLayout()) {
+            // The change cannot be applied right now (no adapter yet, updates suspended or the
+            // RecyclerView is computing its layout). It used to be dropped silently, leaving
+            // the list out of sync with `items` until some unrelated refresh happened: for
+            // example, data pushed into the ObservableArray before the adapter exists showed
+            // an empty list. Schedule a full refresh instead (the array already holds the new
+            // data). While updates are suspended, `resumeUpdates(true)` is the caller's job.
+            if (!this._dataUpdatesSuspended && !this._pendingRefresh) {
+                this._pendingRefresh = true;
+                setTimeout(() => {
+                    this._pendingRefresh = false;
+                    this.refresh();
+                }, 0);
+            }
             return;
         }
         if (Trace.isEnabled()) {
@@ -1219,24 +1233,21 @@ export class CollectionView extends CollectionViewBase {
     }
     @profile
     public templateKeyToNativeItem(key: string): number {
-        if (!this.templateTypeNumberString) {
-            this.templateTypeNumberString = new Map<string, number>();
-            this._currentNativeItemType = 0;
-            this._itemTemplatesInternal.forEach((v, i) => {
-                this.templateTypeNumberString.set(v.key, this._currentNativeItemType);
-                this.templateStringTypeNumber.set(this._currentNativeItemType, v.key);
-                this.setNativePoolSize(v.key, this._currentNativeItemType);
-                this._currentNativeItemType++;
-            });
-            this._currentNativeItemType = Math.max(this._itemTemplatesInternal.size, 100);
-            // templates will be numbered 0,1,2,3... for named templates
-            // default/unnamed templates will be numbered 100, 101, 102, 103...
-        }
         if (!this.templateTypeNumberString.has(key)) {
-            this.templateTypeNumberString.set(key, this._currentNativeItemType);
-            this.templateStringTypeNumber.set(this._currentNativeItemType, key);
-            this.setNativePoolSize(key, this._currentNativeItemType);
-            this._currentNativeItemType++;
+            // Named templates get a stable view type: their index in `itemTemplates`.
+            // Numbering in request order broke after `clearTemplateTypes()` (called when the
+            // template selector changes): the RecyclerView keeps reusing the holders created
+            // with the previous numbering, so the same view type could now mean a different
+            // template and cells got rendered with the wrong one. Unknown keys start at 100.
+            const templateKeys = this._itemTemplatesInternal ? Array.from(this._itemTemplatesInternal.keys()) : [];
+            let type = templateKeys.indexOf(key.toLowerCase());
+            if (type < 0) {
+                type = Math.max(100, this._currentNativeItemType);
+                this._currentNativeItemType = type + 1;
+            }
+            this.templateTypeNumberString.set(key, type);
+            this.templateStringTypeNumber.set(type, key);
+            this.setNativePoolSize(key, type);
         }
         return this.templateTypeNumberString.get(key);
     }
@@ -1270,7 +1281,13 @@ export class CollectionView extends CollectionViewBase {
     }
 
     getKeyByValue(viewType: number) {
-        return this.templateStringTypeNumber.get(viewType);
+        const key = this.templateStringTypeNumber.get(viewType);
+        if (key !== undefined) {
+            return key;
+        }
+        // After `clearTemplateTypes()` the reverse map is empty until each key is requested
+        // again, but the view type of a named template is its index in `itemTemplates`.
+        return this._itemTemplatesInternal ? Array.from(this._itemTemplatesInternal.keys())[viewType] : undefined;
     }
 
     @profile

--- a/src/collectionview/vue3/component.ts
+++ b/src/collectionview/vue3/component.ts
@@ -63,6 +63,12 @@ export const CollectionView = defineComponent({
         }));
 
         const getSlotName = (item: any, index: number, items: ListItem[]) => props.itemTemplateSelector?.(item, index, items) ?? 'default';
+        // Keep ONE stable selector function. Passing a new arrow function on every render
+        // changes the `itemTemplateSelector` property of the native view, which on Android
+        // clears the template type map and triggers a full `notifyDataSetChanged()` on every
+        // re-render of this component (e.g. whenever any bound attribute of the
+        // CollectionView changes).
+        const itemTemplateSelector = (item: any, index: number, items: ListItem[]) => getSlotName(item, index, items);
 
         const collectionView = ref<any & { nativeView: NSCollectionView }>(null);
 
@@ -125,7 +131,7 @@ export const CollectionView = defineComponent({
                 items: props.items,
                 itemTemplates,
                 onItemLoading,
-                itemTemplateSelector: (item: any, index: number, items: ListItem[]) => getSlotName(item, index, items)
+                itemTemplateSelector
             });
     }
 });

--- a/src/collectionview/vue3/component.ts
+++ b/src/collectionview/vue3/component.ts
@@ -63,12 +63,13 @@ export const CollectionView = defineComponent({
         }));
 
         const getSlotName = (item: any, index: number, items: ListItem[]) => props.itemTemplateSelector?.(item, index, items) ?? 'default';
+        const createItemTemplateSelector = () => (item: any, index: number, items: ListItem[]) => getSlotName(item, index, items);
         // Keep ONE stable selector function. Passing a new arrow function on every render
         // changes the `itemTemplateSelector` property of the native view, which on Android
         // clears the template type map and triggers a full `notifyDataSetChanged()` on every
         // re-render of this component (e.g. whenever any bound attribute of the
         // CollectionView changes).
-        const itemTemplateSelector = (item: any, index: number, items: ListItem[]) => getSlotName(item, index, items);
+        const itemTemplateSelector = ref(createItemTemplateSelector());
 
         const collectionView = ref<any & { nativeView: NSCollectionView }>(null);
 
@@ -79,6 +80,15 @@ export const CollectionView = defineComponent({
             (oldVal, newVal) => {
                 if (!(oldVal instanceof Observable)) {
                     collectionView.value.setAttribute('items', newVal);
+                }
+            }
+        );
+        watch(
+            () => props.itemTemplateSelector,
+            (newValue, oldValue) => {
+                if (newValue !== oldValue) {
+                    itemTemplateSelector.value = createItemTemplateSelector();
+                    collectionView.value?.setAttribute('itemTemplateSelector', itemTemplateSelector.value);
                 }
             }
         );
@@ -131,7 +141,7 @@ export const CollectionView = defineComponent({
                 items: props.items,
                 itemTemplates,
                 onItemLoading,
-                itemTemplateSelector
+                itemTemplateSelector: itemTemplateSelector.value
             });
     }
 });


### PR DESCRIPTION
## Summary

Three related Android issues that show up as cells rendered with the **wrong template** (or an empty list) when a `CollectionView` uses several templates through `itemTemplateSelector`. Found while debugging a chat screen (day separators, incoming and outgoing bubbles, typing row) built with `nativescript-vue` 3 on `@nativescript/core` 9.1.

1. **Vue 3 component: new `itemTemplateSelector` function on every render.** The render function passed a fresh arrow function each time, so every re-render of the component (for example when any bound attribute of the `<CollectionView>` changes, like `:opacity`) changed the native `itemTemplateSelector` property. On Android that handler calls `clearTemplateTypes()` and `refresh()` (a full `notifyDataSetChanged()`). The selector is now created once in `setup()`.

2. **Android: view types were numbered in request order.** `templateKeyToNativeItem` assigned the next free number to whatever key was asked first (the branch that numbered templates from `itemTemplates` was dead code: the maps are always initialized in the constructor). After `clearTemplateTypes()` the numbering started again from 0, so the same view type could now mean a different template while the RecyclerView kept reusing the holders created with the old numbering. Result: holders (and the Vue cells rendered inside them) bound to items of another template. Named templates now always get their index in `itemTemplates` as view type (unknown keys start at 100, as the original comment intended), and `getKeyByValue` derives the key the same way when the reverse map is empty.

3. **Android: `onSourceCollectionChanged` dropped changes silently.** When the adapter did not exist yet, updates were suspended, or the RecyclerView was computing its layout, the ObservableArray change was simply ignored. Data pushed into the array before the adapter existed left the list empty until some unrelated refresh happened (which, until fix 1, was the spurious refresh caused by the selector). A deferred `refresh()` is now scheduled instead. While updates are suspended nothing changes: `resumeUpdates(true)` is still the caller's responsibility.

## How to reproduce (before)

Vue 3 app, `CollectionView` with an `itemTemplateSelector` returning e.g. `header` / `in` / `out`, items in an `ObservableArray`, and any dynamic attribute bound on the component. Fill the array shortly after the page loads and toggle the attribute: some cells come out rendered with a different template than the one the selector returned for their item (or the list stays empty when the data arrived before the adapter was created).

## Verification

Tested on an Android emulator (Pixel 8, API 35) with `@nativescript/core` 9.1.1 and `nativescript-vue` 3.0.3, dumping the native view tree with `uiautomator` while scrolling and while items were inserted, removed and replaced. Before: cells with the wrong template and an empty list on first load. After: every cell matches its item's template and the first page renders as soon as it is pushed. `tsc` reports no new errors for the two changed files. iOS is not affected by 2 and 3 (it reuses cells by template name), but it benefits from 1 (no needless refresh on every render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
